### PR TITLE
Add env attribute for people-depot

### DIFF
--- a/terraform-incubator/people-depot/dev/main.tf
+++ b/terraform-incubator/people-depot/dev/main.tf
@@ -27,6 +27,7 @@ module "dev" {
   root_db_password = var.root_db_password
   app_db_password  = var.app_db_password
   container_image  = "035866691871.dkr.ecr.us-west-2.amazonaws.com/people-depot-backend-dev:latest"
+  environment      = "dev"
 }
 
 moved {

--- a/terraform-incubator/people-depot/project/main.tf
+++ b/terraform-incubator/people-depot/project/main.tf
@@ -16,7 +16,8 @@ module "people_depot" {
   container_cpu   = 256
   aws_managed_dns = false
   container_env_vars = {
-    SQL_HOST          = "incubator-prod-database.cewewwrvdqjn.us-west-2.rds.amazonaws.com"
+    SQL_PASSWORD      = var.app_db_password
+    SQL_HOST          = data.terraform_remote_state.shared.outputs.db_address
     COGNITO_USER_POOL = "us-west-2_Fn4rkZpuB"
 
     COGNITO_AWS_REGION   = "us-west-2"
@@ -25,7 +26,6 @@ module "people_depot" {
     SECRET_KEY           = "foo"
     SQL_DATABASE         = "people_depot_dev"
     SQL_ENGINE           = "django.db.backends.postgresql"
-    SQL_PASSWORD         = var.app_db_password
     SQL_PORT             = 5432
     SQL_USER             = "people_depot"
   }
@@ -37,7 +37,7 @@ module "people_depot" {
   postgres_database = {}
   region            = "us-west-2"
   health_check_path = "/"
-  environment       = "dev"
+  environment       = var.environment
   application_type  = "backend"
   launch_type       = "FARGATE"
   container_port    = 8000
@@ -74,5 +74,9 @@ variable "app_db_password" {
 }
 
 variable "container_image" {
+  type = string
+}
+
+variable "environment" {
   type = string
 }

--- a/terraform-incubator/shared_resources/all/main.tf
+++ b/terraform-incubator/shared_resources/all/main.tf
@@ -41,6 +41,9 @@ output "cluster_id" {
 output "task_execution_role_arn" {
   value = data.terraform_remote_state.shared["ecs"].outputs.task_execution_role_arn
 }
+output "db_address" {
+  value = data.terraform_remote_state.shared["rds"].outputs.db_address
+}
 output "db_instance_endpoint" {
   value = data.terraform_remote_state.shared["rds"].outputs.db_instance_endpoint
 }


### PR DESCRIPTION
A couple of little oversights in the Terraform example migration corrected -

And `env` attribute added for the people-depot project,
since e.g. the prod specialization will want to override that.

A DB URL pulled in from the `shared_resources` module instead of hardcoded.

I've created issues for a couple of other hard-coded values
that clearly come from somewhere in AWS, and should be made Terraform references.
