### PR TITLE
Migrating vrms-backend to terraform

### DIFF
--- a/terraform-incubator/vrms-backend/dev/main.tf
+++ b/terraform-incubator/vrms-backend/dev/main.tf
@@ -20,4 +20,15 @@ module "dev" {
   container_image  = "035866691871.dkr.ecr.us-west-2.amazonaws.com/vrms-backend-dev:latest"
   host_names       = ["dev.vrms.io"]
   database_url     = "mongodb+srv://editor:557Ith3jq7ap2mnO@cluster0.5buwz.mongodb.net/vrms-test?retryWrites=true&w=majority"
+
+  # These are input locally through a .tfvars file
+  gmail_client_id = var.gmail_client_id
+  gmail_refresh_token = var.gmail_refresh_token
+  gmail_secret_id = var.gmail_secret_id
+  mailhog_password = var.mailhog_password
+  slack_bot_token = var.slack_bot_token
+  slack_client_id = var.slack_client_id
+  slack_client_secret = var.slack_client_secret
+  slack_oauth_token = var.slack_oauth_token
+  slack_signing_secret = var.slack_signing_secret
 }

--- a/terraform-incubator/vrms-backend/dev/main.tf
+++ b/terraform-incubator/vrms-backend/dev/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket         = "hlfa-incubator-terragrunt"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+    key            = "terragrunt-states/incubator/projects-dev/vrms-backend/terraform.tfstate"
+    region         = "us-west-2"
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "dev" {
+  source = "../project"
+
+  environment      = "dev"
+  root_db_password = "password" // not really needed because we don't use a postgres database in this project
+  container_image  = "035866691871.dkr.ecr.us-west-2.amazonaws.com/vrms-backend-dev:latest"
+  host_names       = ["dev.vrms.io"]
+  database_url     = "mongodb+srv://editor:557Ith3jq7ap2mnO@cluster0.5buwz.mongodb.net/vrms-test?retryWrites=true&w=majority"
+}

--- a/terraform-incubator/vrms-backend/dev/moves.tf
+++ b/terraform-incubator/vrms-backend/dev/moves.tf
@@ -1,0 +1,44 @@
+moved {
+  from = aws_appautoscaling_policy.ecs_autoscale_cpu
+  to   = module.dev.module.vrms-backend.aws_appautoscaling_policy.ecs_autoscale_cpu
+}
+moved {
+  from = aws_appautoscaling_policy.ecs_autoscale_memory
+  to   = module.dev.module.vrms-backend.aws_appautoscaling_policy.ecs_autoscale_memory
+}
+moved {
+  from = aws_appautoscaling_target.ecs_target
+  to   = module.dev.module.vrms-backend.aws_appautoscaling_target.ecs_target
+}
+moved {
+  from = aws_lb_listener_rule.static
+  to   = module.dev.module.vrms-backend.aws_lb_listener_rule.static
+}
+moved {
+  from = aws_route53_record.www["dev.vrms.io"]
+  to   = module.dev.module.vrms-backend.aws_route53_record.www["dev.vrms.io"]
+}
+moved {
+  from = aws_security_group.fargate
+  to   = module.dev.module.vrms-backend.aws_security_group.fargate
+}
+moved {
+  from = aws_cloudwatch_log_group.cwlogs
+  to   = module.dev.module.vrms-backend.aws_cloudwatch_log_group.cwlogs
+}
+moved {
+  from = aws_ecs_service.fargate
+  to   = module.dev.module.vrms-backend.aws_ecs_service.fargate
+}
+moved {
+  from = aws_lb_target_group.this
+  to   = module.dev.module.vrms-backend.aws_lb_target_group.this
+}
+moved {
+  from = aws_ecs_task_definition.task
+  to   = module.dev.module.vrms-backend.aws_ecs_task_definition.task
+}
+moved {
+  from = module.ecr.aws_ecr_repository.this
+  to   = module.dev.module.vrms-backend.module.ecr.aws_ecr_repository.this
+}

--- a/terraform-incubator/vrms-backend/dev/variables.tf
+++ b/terraform-incubator/vrms-backend/dev/variables.tf
@@ -1,26 +1,3 @@
-variable "root_db_password" {
-  type        = string
-  description = "root database password"
-}
-
-variable "container_image" {
-  type = string
-}
-
-variable "host_names" {
-  type = list(string)
-  description = "list of host names for route 53 and listener rules"
-}
-
-variable "environment" {
-  type = string
-}
-
-variable "database_url" {
-  type = string
-  description = "The url for the database which is set as an environment variable"
-}
-
 variable "gmail_client_id" {
     type = string
 }

--- a/terraform-incubator/vrms-backend/prod/main.tf
+++ b/terraform-incubator/vrms-backend/prod/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+    bucket         = "hlfa-incubator-terragrunt"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+    key            = "terragrunt-states/incubator/projects-prod/vrms-backend/terraform.tfstate"
+    region         = "us-west-2"
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "prod" {
+  source = "../project"
+
+  environment      = "prod"
+  root_db_password = "password" // not really needed because we don't use a postgres database in this project
+  container_image  = "035866691871.dkr.ecr.us-west-2.amazonaws.com/vrms-backend-dev:latest"
+  host_names       = ["vrms.io"]
+  database_url     = "mongodb+srv://admin:admin123@cluster0-haogu.mongodb.net/db?retryWrites=true&w=majority"
+}

--- a/terraform-incubator/vrms-backend/prod/main.tf
+++ b/terraform-incubator/vrms-backend/prod/main.tf
@@ -20,4 +20,15 @@ module "prod" {
   container_image  = "035866691871.dkr.ecr.us-west-2.amazonaws.com/vrms-backend-dev:latest"
   host_names       = ["vrms.io"]
   database_url     = "mongodb+srv://admin:admin123@cluster0-haogu.mongodb.net/db?retryWrites=true&w=majority"
+
+  # These are input locally through a .tfvars file
+  gmail_client_id = var.gmail_client_id
+  gmail_refresh_token = var.gmail_refresh_token
+  gmail_secret_id = var.gmail_secret_id
+  mailhog_password = var.mailhog_password
+  slack_bot_token = var.slack_bot_token
+  slack_client_id = var.slack_client_id
+  slack_client_secret = var.slack_client_secret
+  slack_oauth_token = var.slack_oauth_token
+  slack_signing_secret = var.slack_signing_secret
 }

--- a/terraform-incubator/vrms-backend/prod/moves.tf
+++ b/terraform-incubator/vrms-backend/prod/moves.tf
@@ -1,0 +1,44 @@
+moved {
+  from = aws_appautoscaling_policy.ecs_autoscale_cpu
+  to   = module.prod.module.vrms-backend.aws_appautoscaling_policy.ecs_autoscale_cpu
+}
+moved {
+  from = aws_appautoscaling_policy.ecs_autoscale_memory
+  to   = module.prod.module.vrms-backend.aws_appautoscaling_policy.ecs_autoscale_memory
+}
+moved {
+  from = aws_appautoscaling_target.ecs_target
+  to   = module.prod.module.vrms-backend.aws_appautoscaling_target.ecs_target
+}
+moved {
+  from = aws_lb_listener_rule.static
+  to   = module.prod.module.vrms-backend.aws_lb_listener_rule.static
+}
+moved {
+  from = aws_route53_record.www["vrms.io"]
+  to   = module.prod.module.vrms-backend.aws_route53_record.www["vrms.io"]
+}
+moved {
+  from = aws_security_group.fargate
+  to   = module.prod.module.vrms-backend.aws_security_group.fargate
+}
+moved {
+  from = aws_cloudwatch_log_group.cwlogs
+  to   = module.prod.module.vrms-backend.aws_cloudwatch_log_group.cwlogs
+}
+moved {
+  from = aws_ecs_service.fargate
+  to   = module.prod.module.vrms-backend.aws_ecs_service.fargate
+}
+moved {
+  from = aws_lb_target_group.this
+  to   = module.prod.module.vrms-backend.aws_lb_target_group.this
+}
+moved {
+  from = aws_ecs_task_definition.task
+  to   = module.prod.module.vrms-backend.aws_ecs_task_definition.task
+}
+moved {
+  from = module.ecr.aws_ecr_repository.this
+  to   = module.prod.module.vrms-backend.module.ecr.aws_ecr_repository.this
+}

--- a/terraform-incubator/vrms-backend/prod/variables.tf
+++ b/terraform-incubator/vrms-backend/prod/variables.tf
@@ -1,26 +1,3 @@
-variable "root_db_password" {
-  type        = string
-  description = "root database password"
-}
-
-variable "container_image" {
-  type = string
-}
-
-variable "host_names" {
-  type = list(string)
-  description = "list of host names for route 53 and listener rules"
-}
-
-variable "environment" {
-  type = string
-}
-
-variable "database_url" {
-  type = string
-  description = "The url for the database which is set as an environment variable"
-}
-
 variable "gmail_client_id" {
     type = string
 }

--- a/terraform-incubator/vrms-backend/project/main.tf
+++ b/terraform-incubator/vrms-backend/project/main.tf
@@ -19,20 +19,20 @@ module "vrms-backend" {
     BACKEND_PORT          = 4000
     CUSTOM_REQUEST_HEADER = "nAb3kY-S%qE#4!d"
     DATABASE_URL          = var.database_url
-    GMAIL_CLIENT_ID       = "839934869475-lul9tkasi47a6h5cv7fa4kb9v1h84jp6.apps.googleusercontent.com"
+    GMAIL_CLIENT_ID       = var.gmail_client_id
     GMAIL_EMAIL           = "vrms.signup@gmail.com"
-    GMAIL_REFRESH_TOKEN   = "1//040kWEcEwkx-JCgYIARAAGAQSNwF-L9IrNctLO4dnlTy0Mi30RraN5JyZti4xzMNMfeEvkzgkoUYpVRUUyJbE3a1x0IUfxDNfwL8"
-    GMAIL_SECRET_ID       = "eYZaaMwQWMBZ4rHY613HO15r"
-    MAILHOG_PASSWORD      = "password"
+    GMAIL_REFRESH_TOKEN   = var.gmail_refresh_token
+    GMAIL_SECRET_ID       = var.gmail_secret_id
+    MAILHOG_PASSWORD      = var.mailhog_password
     MAILHOG_PORT          = 1025
     MAILHOG_USER          = "user"
     REACT_APP_PROXY       = "http://localhost:4000"
-    SLACK_BOT_TOKEN       = "xoxb-1302534787829-1302590110453-YaWx40V2aJLNX4SHc1VbccuH"
+    SLACK_BOT_TOKEN       = var.slack_bot_token
     SLACK_CHANNEL_ID      = "D018H4TM94P"
-    SLACK_CLIENT_ID       = "1302534787829.1327799404688"
-    SLACK_CLIENT_SECRET   = "75692834e0d83655b5a06014cbc2a911"
-    SLACK_OAUTH_TOKEN     = "xoxp-1302534787829-1327746472832-1316638804417-7b7da90bec9c6b45beaa2d83ce3ed881"
-    SLACK_SIGNING_SECRET  = "92ef694145d1282cd9461453b0af45f5"
+    SLACK_CLIENT_ID       = var.slack_client_id
+    SLACK_CLIENT_SECRET   = var.slack_client_secret
+    SLACK_OAUTH_TOKEN     = var.slack_oauth_token
+    SLACK_SIGNING_SECRET  = var.slack_signing_secret
     SLACK_TEAM_ID         = "T018WFQP5QD"
   }
   vpc_cidr          = "10.10.0.0/16"
@@ -53,7 +53,7 @@ module "vrms-backend" {
   cluster_name      = "incubator-prod"
   path_patterns     = ["/api/*"]
   tags = {
-    last_changed      = "Mon 2023-Oct-23 13:52:00"
+    last_changed      = "Sat 2023-Nov-11 11:10:00"
     terraform_managed = "true"
   }
 

--- a/terraform-incubator/vrms-backend/project/main.tf
+++ b/terraform-incubator/vrms-backend/project/main.tf
@@ -1,0 +1,70 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+
+  config = {
+    bucket         = "hlfa-incubator-terragrunt"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+    key            = "terragrunt-states/incubator/./terraform.tfstate"
+    region         = "us-west-2"
+  }
+}
+
+module "vrms-backend" {
+  source = "../../../terraform-modules/service"
+
+  container_cpu   = 256
+  aws_managed_dns = true
+  container_env_vars = {
+    BACKEND_PORT          = 4000
+    CUSTOM_REQUEST_HEADER = "nAb3kY-S%qE#4!d"
+    DATABASE_URL          = var.database_url
+    GMAIL_CLIENT_ID       = "839934869475-lul9tkasi47a6h5cv7fa4kb9v1h84jp6.apps.googleusercontent.com"
+    GMAIL_EMAIL           = "vrms.signup@gmail.com"
+    GMAIL_REFRESH_TOKEN   = "1//040kWEcEwkx-JCgYIARAAGAQSNwF-L9IrNctLO4dnlTy0Mi30RraN5JyZti4xzMNMfeEvkzgkoUYpVRUUyJbE3a1x0IUfxDNfwL8"
+    GMAIL_SECRET_ID       = "eYZaaMwQWMBZ4rHY613HO15r"
+    MAILHOG_PASSWORD      = "password"
+    MAILHOG_PORT          = 1025
+    MAILHOG_USER          = "user"
+    REACT_APP_PROXY       = "http://localhost:4000"
+    SLACK_BOT_TOKEN       = "xoxb-1302534787829-1302590110453-YaWx40V2aJLNX4SHc1VbccuH"
+    SLACK_CHANNEL_ID      = "D018H4TM94P"
+    SLACK_CLIENT_ID       = "1302534787829.1327799404688"
+    SLACK_CLIENT_SECRET   = "75692834e0d83655b5a06014cbc2a911"
+    SLACK_OAUTH_TOKEN     = "xoxp-1302534787829-1327746472832-1316638804417-7b7da90bec9c6b45beaa2d83ce3ed881"
+    SLACK_SIGNING_SECRET  = "92ef694145d1282cd9461453b0af45f5"
+    SLACK_TEAM_ID         = "T018WFQP5QD"
+  }
+  vpc_cidr          = "10.10.0.0/16"
+  host_names        = var.host_names
+  root_db_username  = "postgres" // this is required even though postgres_database controls whether or not it's even used
+  root_db_password  = var.root_db_password
+  lambda_function   = "incubator_multi-tenant-db"
+  container_memory  = 512
+  project_name      = "vrms"
+  postgres_database = {}
+  region            = "us-west-2"
+  health_check_path = "/api/healthcheck"
+  environment       = var.environment
+  application_type  = "backend"
+  launch_type       = "FARGATE"
+  container_port    = 4000
+  desired_count     = 1
+  cluster_name      = "incubator-prod"
+  path_patterns     = ["/api/*"]
+  tags = {
+    last_changed      = "Mon 2023-Oct-23 13:52:00"
+    terraform_managed = "true"
+  }
+
+  container_image = var.container_image
+
+  alb_external_dns        = data.terraform_remote_state.shared.outputs.alb_external_dns
+  cluster_id              = data.terraform_remote_state.shared.outputs.cluster_id
+  task_execution_role_arn = data.terraform_remote_state.shared.outputs.task_execution_role_arn
+  alb_security_group_id   = data.terraform_remote_state.shared.outputs.alb_security_group_id
+  alb_https_listener_arn  = data.terraform_remote_state.shared.outputs.alb_https_listener_arn
+  db_instance_endpoint    = data.terraform_remote_state.shared.outputs.db_instance_endpoint
+  vpc_id                  = data.terraform_remote_state.shared.outputs.vpc_id
+  public_subnet_ids       = data.terraform_remote_state.shared.outputs.public_subnet_ids
+}

--- a/terraform-incubator/vrms-backend/project/variables.tf
+++ b/terraform-incubator/vrms-backend/project/variables.tf
@@ -1,0 +1,22 @@
+variable "root_db_password" {
+  type        = string
+  description = "root database password"
+}
+
+variable "container_image" {
+  type = string
+}
+
+variable "host_names" {
+  type = list(string)
+  description = "list of host names for route 53 and listener rules"
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "database_url" {
+  type = string
+  description = "The url for the database which is set as an environment variable"
+}


### PR DESCRIPTION
Migrating the configuration for vrms-backend to the new `terraform-incubator` directory.

This PR is strictly additive it does not remove any of the old code in the `incubator` directory.

Linked to this issue - https://github.com/hackforla/VRMS/issues/1497