### PR TITLE
docs: added-project-documentation-using-terraform-docs

### DIFF
--- a/terraform-incubator/access-the-data/.terraform.docs.yml
+++ b/terraform-incubator/access-the-data/.terraform.docs.yml
@@ -1,0 +1,60 @@
+formatter: "markdown table" # this is required
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: terraform-incubator
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  # Groups
+
+  This module declares all of the resources necessary to create AWS IAM groups.
+
+  {{ .Header }}
+  {{ .Modules }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Footer }}
+  To automatically update this documentation, install terraform-docs on your local machine run the following: 
+      cd <directory of README location to update>
+      terraform-docs -c .terraform.docs.yml . 
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->    
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform-incubator/access-the-data/README.md
+++ b/terraform-incubator/access-the-data/README.md
@@ -1,0 +1,40 @@
+<!-- BEGIN_TF_DOCS -->
+# Groups
+
+This module declares all of the resources necessary to create AWS IAM groups.
+
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_access-the-data"></a> [access-the-data](#module\_access-the-data) | ../../terraform-modules/multi-container-service | n/a |
+| <a name="module_database"></a> [database](#module\_database) | ../../terraform-modules/database | n/a |
+| <a name="module_datastore_database"></a> [datastore\_database](#module\_datastore\_database) | ../../terraform-modules/database | n/a |
+| <a name="module_secrets"></a> [secrets](#module\_secrets) | ../../terraform-modules/cheap-secrets | n/a |
+| <a name="module_zone"></a> [zone](#module\_zone) | ../../terraform-modules/project-zone | n/a |
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_instance.shared](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/db_instance) | data source |
+| [aws_ssm_parameter.rds_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [terraform_remote_state.shared](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_postgresql"></a> [postgresql](#requirement\_postgresql) | ~> 1.21.0 |
+
+To automatically update this documentation, install terraform-docs on your local machine run the following: 
+    cd <directory of README location to update>
+    terraform-docs -c .terraform.docs.yml . 
+<!-- END_TF_DOCS -->    

--- a/terraform-incubator/people-depot/project/.terraform.docs.yml
+++ b/terraform-incubator/people-depot/project/.terraform.docs.yml
@@ -1,0 +1,60 @@
+formatter: "markdown table" # this is required
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: terraform-incubator
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  # Groups
+
+  This module declares all of the resources necessary to create AWS IAM groups.
+
+  {{ .Header }}
+  {{ .Modules }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Footer }}
+  To automatically update this documentation, install terraform-docs on your local machine run the following: 
+      cd <directory of README location to update>
+      terraform-docs -c .terraform.docs.yml . 
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->    
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform-incubator/people-depot/project/README.md
+++ b/terraform-incubator/people-depot/project/README.md
@@ -1,0 +1,35 @@
+<!-- BEGIN_TF_DOCS -->
+# Groups
+
+This module declares all of the resources necessary to create AWS IAM groups.
+
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_people_depot"></a> [people\_depot](#module\_people\_depot) | ../../../terraform-modules/service | n/a |
+## Resources
+
+| Name | Type |
+|------|------|
+| [terraform_remote_state.shared](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_db_password"></a> [app\_db\_password](#input\_app\_db\_password) | n/a | `string` | n/a | yes |
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | n/a | `string` | n/a | yes |
+| <a name="input_root_db_password"></a> [root\_db\_password](#input\_root\_db\_password) | root database password | `string` | n/a | yes |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+
+To automatically update this documentation, install terraform-docs on your local machine run the following: 
+    cd <directory of README location to update>
+    terraform-docs -c .terraform.docs.yml . 
+<!-- END_TF_DOCS -->    

--- a/terraform-incubator/vrms-backend/dev/.terraform.docs.yml
+++ b/terraform-incubator/vrms-backend/dev/.terraform.docs.yml
@@ -1,0 +1,60 @@
+formatter: "markdown table" # this is required
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: terraform-incubatorgit 
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  # Groups
+
+  This module declares all of the resources necessary to create AWS IAM groups.
+
+  {{ .Header }}
+  {{ .Modules }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Footer }}
+  To automatically update this documentation, install terraform-docs on your local machine run the following: 
+      cd <directory of README location to update>
+      terraform-docs -c .terraform.docs.yml . 
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->    
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform-incubator/vrms-backend/dev/.terraform.docs.yml
+++ b/terraform-incubator/vrms-backend/dev/.terraform.docs.yml
@@ -6,7 +6,7 @@ footer-from: ""
 
 recursive:
   enabled: false
-  path: terraform-incubatorgit 
+  path: terraform-incubator 
 
 sections:
   hide: []

--- a/terraform-incubator/vrms-backend/dev/README.md
+++ b/terraform-incubator/vrms-backend/dev/README.md
@@ -1,0 +1,33 @@
+<!-- BEGIN_TF_DOCS -->
+# Groups
+
+This module declares all of the resources necessary to create AWS IAM groups.
+
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dev"></a> [dev](#module\_dev) | ../project | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_gmail_client_id"></a> [gmail\_client\_id](#input\_gmail\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_refresh_token"></a> [gmail\_refresh\_token](#input\_gmail\_refresh\_token) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_secret_id"></a> [gmail\_secret\_id](#input\_gmail\_secret\_id) | n/a | `string` | n/a | yes |
+| <a name="input_mailhog_password"></a> [mailhog\_password](#input\_mailhog\_password) | n/a | `string` | n/a | yes |
+| <a name="input_slack_bot_token"></a> [slack\_bot\_token](#input\_slack\_bot\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_id"></a> [slack\_client\_id](#input\_slack\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_secret"></a> [slack\_client\_secret](#input\_slack\_client\_secret) | n/a | `string` | n/a | yes |
+| <a name="input_slack_oauth_token"></a> [slack\_oauth\_token](#input\_slack\_oauth\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_signing_secret"></a> [slack\_signing\_secret](#input\_slack\_signing\_secret) | n/a | `string` | n/a | yes |
+
+
+
+
+To automatically update this documentation, install terraform-docs on your local machine run the following: 
+    cd <directory of README location to update>
+    terraform-docs -c .terraform.docs.yml . 
+<!-- END_TF_DOCS -->    

--- a/terraform-incubator/vrms-backend/prod/.terraform.docs.yml
+++ b/terraform-incubator/vrms-backend/prod/.terraform.docs.yml
@@ -1,0 +1,60 @@
+formatter: "markdown table" # this is required
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: terraform-incubator
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  # Groups
+
+  This module declares all of the resources necessary to create AWS IAM groups.
+
+  {{ .Header }}
+  {{ .Modules }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Footer }}
+  To automatically update this documentation, install terraform-docs on your local machine run the following: 
+      cd <directory of README location to update>
+      terraform-docs -c .terraform.docs.yml . 
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->    
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform-incubator/vrms-backend/prod/README.md
+++ b/terraform-incubator/vrms-backend/prod/README.md
@@ -1,0 +1,33 @@
+<!-- BEGIN_TF_DOCS -->
+# Groups
+
+This module declares all of the resources necessary to create AWS IAM groups.
+
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_prod"></a> [prod](#module\_prod) | ../project | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_gmail_client_id"></a> [gmail\_client\_id](#input\_gmail\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_refresh_token"></a> [gmail\_refresh\_token](#input\_gmail\_refresh\_token) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_secret_id"></a> [gmail\_secret\_id](#input\_gmail\_secret\_id) | n/a | `string` | n/a | yes |
+| <a name="input_mailhog_password"></a> [mailhog\_password](#input\_mailhog\_password) | n/a | `string` | n/a | yes |
+| <a name="input_slack_bot_token"></a> [slack\_bot\_token](#input\_slack\_bot\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_id"></a> [slack\_client\_id](#input\_slack\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_secret"></a> [slack\_client\_secret](#input\_slack\_client\_secret) | n/a | `string` | n/a | yes |
+| <a name="input_slack_oauth_token"></a> [slack\_oauth\_token](#input\_slack\_oauth\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_signing_secret"></a> [slack\_signing\_secret](#input\_slack\_signing\_secret) | n/a | `string` | n/a | yes |
+
+
+
+
+To automatically update this documentation, install terraform-docs on your local machine run the following: 
+    cd <directory of README location to update>
+    terraform-docs -c .terraform.docs.yml . 
+<!-- END_TF_DOCS -->    

--- a/terraform-incubator/vrms-backend/project/.terraform.docs.yml
+++ b/terraform-incubator/vrms-backend/project/.terraform.docs.yml
@@ -1,0 +1,60 @@
+formatter: "markdown table" # this is required
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: terraform-incubator
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  # Groups
+
+  This module declares all of the resources necessary to create AWS IAM groups.
+
+  {{ .Header }}
+  {{ .Modules }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Footer }}
+  To automatically update this documentation, install terraform-docs on your local machine run the following: 
+      cd <directory of README location to update>
+      terraform-docs -c .terraform.docs.yml . 
+output:
+  file: README.md
+  mode: replace
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->    
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform-incubator/vrms-backend/project/README.md
+++ b/terraform-incubator/vrms-backend/project/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+# Groups
+
+This module declares all of the resources necessary to create AWS IAM groups.
+
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vrms-backend"></a> [vrms-backend](#module\_vrms-backend) | ../../../terraform-modules/service | n/a |
+## Resources
+
+| Name | Type |
+|------|------|
+| [terraform_remote_state.shared](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | n/a | `string` | n/a | yes |
+| <a name="input_database_url"></a> [database\_url](#input\_database\_url) | The url for the database which is set as an environment variable | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_client_id"></a> [gmail\_client\_id](#input\_gmail\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_refresh_token"></a> [gmail\_refresh\_token](#input\_gmail\_refresh\_token) | n/a | `string` | n/a | yes |
+| <a name="input_gmail_secret_id"></a> [gmail\_secret\_id](#input\_gmail\_secret\_id) | n/a | `string` | n/a | yes |
+| <a name="input_host_names"></a> [host\_names](#input\_host\_names) | list of host names for route 53 and listener rules | `list(string)` | n/a | yes |
+| <a name="input_mailhog_password"></a> [mailhog\_password](#input\_mailhog\_password) | n/a | `string` | n/a | yes |
+| <a name="input_root_db_password"></a> [root\_db\_password](#input\_root\_db\_password) | root database password | `string` | n/a | yes |
+| <a name="input_slack_bot_token"></a> [slack\_bot\_token](#input\_slack\_bot\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_id"></a> [slack\_client\_id](#input\_slack\_client\_id) | n/a | `string` | n/a | yes |
+| <a name="input_slack_client_secret"></a> [slack\_client\_secret](#input\_slack\_client\_secret) | n/a | `string` | n/a | yes |
+| <a name="input_slack_oauth_token"></a> [slack\_oauth\_token](#input\_slack\_oauth\_token) | n/a | `string` | n/a | yes |
+| <a name="input_slack_signing_secret"></a> [slack\_signing\_secret](#input\_slack\_signing\_secret) | n/a | `string` | n/a | yes |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+
+To automatically update this documentation, install terraform-docs on your local machine run the following: 
+    cd <directory of README location to update>
+    terraform-docs -c .terraform.docs.yml . 
+<!-- END_TF_DOCS -->    


### PR DESCRIPTION
Fixes: #57 

### Changes made

Added documentation to terraform projects in the `terraform-incubator` directory, the documentation is provided using terraform-docs.

### Questions

- Do we have to produce documentation to `terraform-incubator/people-depot/dev` directory also as it is a sub-directory, but it is not mentioned in the issue ?
- Should the path variable under recursive section be `path: modules` or `path: terraform-incubator`, as terraform-incubator is the top level directory ?