### PR TITLE
update route 53 configuration to handle root and subdomain DNS records

### DIFF
--- a/terraform-modules/service/r53.tf
+++ b/terraform-modules/service/r53.tf
@@ -4,8 +4,24 @@ data "aws_route53_zone" "selected" {
   private_zone = false
 }
 
-resource "aws_route53_record" "www" {
-  for_each = var.aws_managed_dns ? toset(var.host_names) : []
+# Resource for root domain A record with alias
+resource "aws_route53_record" "root" {
+  count = var.aws_managed_dns && length(regexall("[^.]*?.[^.]*?$", var.host_names[0])) > 0 ? 1 : 0
+
+  zone_id = data.aws_route53_zone.selected[0].zone_id
+  name    = regexall("[^.]*?.[^.]*?$", var.host_names[0])[0]
+  type    = "A"
+
+  alias {
+    name                   = var.alb_external_dns
+    zone_id                = data.aws_route53_zone.selected[0].zone_id
+    evaluate_target_health = false
+  }
+}
+
+# Resource for subdomain CNAME records
+resource "aws_route53_record" "subdomain" {
+  for_each = var.aws_managed_dns ? { for v in var.host_names : v => v if v != regexall("[^.]*?.[^.]*?$", var.host_names[0])[0] } : {}
 
   zone_id = data.aws_route53_zone.selected[0].zone_id
   name    = each.value
@@ -21,5 +37,10 @@ variable "alb_external_dns" {
 
 variable "aws_managed_dns" {
   type        = bool
-  description = "flag to either create record if domain is managed in AWS or output ALB DNS for user to manually create"
+  description = "Flag to either create record if domain is managed in AWS or output ALB DNS for user to manually create"
+}
+
+variable "host_names" {
+  description = "List of host names including the root domain and subdomains"
+  type        = list(string)
 }

--- a/terraform-modules/service/r53.tf
+++ b/terraform-modules/service/r53.tf
@@ -39,8 +39,3 @@ variable "aws_managed_dns" {
   type        = bool
   description = "Flag to either create record if domain is managed in AWS or output ALB DNS for user to manually create"
 }
-
-variable "host_names" {
-  description = "List of host names including the root domain and subdomains"
-  type        = list(string)
-}


### PR DESCRIPTION
### What changed
- Added aws_route53_record resource for root domain (A record with alias) to point to ALB
- Updated aws_route53_record resource for subdomains (CNAME records) to point to ALB
- Refactored logic to use host_names variable dynamically
