### PR TITLE
added cicd resource and ecr resource for use by Civic Tech Jobs

### DIFF
--- a/terraform/projects/civic-tech-jobs/civic-tech-jobs.tf
+++ b/terraform/projects/civic-tech-jobs/civic-tech-jobs.tf
@@ -1,0 +1,15 @@
+// project name, used across all envs
+locals {
+    project_name_civic_tech_jobs = "civic-tech-jobs"
+}
+
+module "civic_tech_jobs_ecr_backend" {
+   source  "../../modules/ecr"
+   project_name = "${local.project_name_civic_tech_jobs}-backend"
+} 
+
+module "civic_tech_jobs_cicd" {
+    source = "../../modules/cicd_integration"
+    project_name = local.project_name_civic_tech_jobs
+    repository_name = "CivicTechJobs"
+}

--- a/terraform/projects/civic-tech-jobs/civic-tech-jobs.tf
+++ b/terraform/projects/civic-tech-jobs/civic-tech-jobs.tf
@@ -3,9 +3,9 @@ locals {
     project_name_civic_tech_jobs = "civic-tech-jobs"
 }
 
-module "civic_tech_jobs_ecr_backend" {
+module "civic_tech_jobs_ecr_fullstack" {
    source  "../../modules/ecr"
-   project_name = "${local.project_name_civic_tech_jobs}-backend"
+   project_name = "${local.project_name_civic_tech_jobs}-fullstack"
 } 
 
 module "civic_tech_jobs_cicd" {


### PR DESCRIPTION
Fixes #94 

#93 was also completed in this step (but 1 resource from the checklist was not found)
### What changes did you make?
  - Added First stage of Incubator resources for Civic Tech Jobs
  - Legacy AWS resources related to CivicTechJobs were also deleted


### Why did you make the changes (we will use this info to test)?
  - These terraform resources are necessary to setup the Civic Tech Jobs Github Action which will push to their ECR entry

