### PR TITLE
Changed ctj dns entry temporarily, will be a subdomain under vrms

### DIFF
--- a/terraform/projects/civic-tech-jobs/environment-stage.tf
+++ b/terraform/projects/civic-tech-jobs/environment-stage.tf
@@ -1,8 +1,8 @@
 
 module "civic_tech_jobs_fullstack_stage_dns_entry" {
    source = "../../modules/dns-entry"
-   subdomain = "stage"
-   zone_id = "Z03052251DU06DMBYE89K"
+   subdomain = "civictechjobs-stage"
+   zone_id = "Z0420800PGQ9JP6DM9EX"
 }
 
 module "civic_tech_jobs_stage_database" {


### PR DESCRIPTION

### What changes did you make?
  - changed DNS entry for civic tech jobs
  - It will now be a subdomain under vrms.io
  -

### Why did you make the changes (we will use this info to test)?
  - the ctj domain is not managed by the incubator aws account, however ctj is going to demo next week and needs to have a working URL. 
  - 
  -
