### PR TITLE
Updated CivicTechJobs DNS

### DIFF
--- a/terraform/projects/civic-tech-jobs/environment-stage.tf
+++ b/terraform/projects/civic-tech-jobs/environment-stage.tf
@@ -1,8 +1,8 @@
 
 module "civic_tech_jobs_fullstack_stage_dns_entry" {
    source = "../../modules/dns-entry"
-   subdomain = "civictechjobs-stage"
-   zone_id = "Z0420800PGQ9JP6DM9EX"
+   subdomain = "stage"
+   zone_id = "Z06949943QJY32WRKG577"
 }
 
 module "civic_tech_jobs_stage_database" {


### PR DESCRIPTION
CTJ was using a subdomain of VRMS, and now that we have civictechjobs.org so I am moving the DNS entry over

Fixes #105 

### What changes did you make?
  - Edited the terraform to point to the civictechjobs.org hosted zone
  - changed subdomain to "stage"
  -

### Why did you make the changes (we will use this info to test)?
  -
  -
  -
