### PR TITLE
terraform/backend tf add required_version ~> 1.12

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "~> 1.12"
   backend "s3" {
   }
   required_providers {


### PR DESCRIPTION
https://github.com/hackforla/incubator/issues/38

Fixes #38

### What changes did you make?
  - Add required_version to incubator terraform/backend.tf
  -
  -

### Why did you make the changes (we will use this info to test)?
  - Confirmed latest stable terraform version 1.12.* at https://github.com/hashicorp/terraform/releases
  -
  -
