### PR TITLE
Add default tags to AWS resources

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -20,3 +20,11 @@ provider "postgresql" {
   connect_timeout = 15
   superuser = false
 }
+
+provider "aws" {
+  default_tags {
+    tags = {
+      managed-by = "terraform-incubator"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #121

### What changes did you make?
  - Added a new AWS provider for the backend, with default tag `managed-by` = `terraform-incubator`.

### Why did you make the changes (we will use this info to test)?
  - To determine what resources are managed by the current version of incubator.

### Testing
  - The Terraform plan created from `backend.tf` does show that the default tag will be applied.