### PR TITLE
Add project tag to ECR repository

### DIFF
--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -14,6 +14,9 @@ variable "project_name" {
 resource "aws_ecr_repository" "this" {
   name                 = var.project_name
   image_tag_mutability = "MUTABLE"
+  tags = {
+    project = var.project_name
+  }
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
Fixes #131

### Inserted on line 17 of `terraform/modules/ecr/main.tf:
```
  tags = {
    project = var.project_name
  }
```

### Why did you make the changes (we will use this info to test)?
  - It was requested in Issue #131. 
  - Terraform tags becomes AWS resource tags, as it appears.
