### PR TITLE
Update TF  plan/apply from PR 146 to use separate OIDC roles

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v3
       with:
-        role-to-assume: arn:aws:iam::035866691871:role/gha-incubator
+        role-to-assume: arn:aws:iam::035866691871:role/incubator-tf-apply
         role-session-name: ghaincubatorsession
         aws-region: us-west-2
 

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -33,8 +33,8 @@ jobs:
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v3
       with:
-        role-to-assume: arn:aws:iam::035866691871:role/gha-incubator
-        role-session-name: ghaincubatorplan
+        role-to-assume: arn:aws:iam::035866691871:role/incubator-tf-plan
+        role-session-name: incubatortfplan
         aws-region: us-west-2
 
     - name: Terraform Plan
@@ -64,3 +64,4 @@ jobs:
         output-method: inject
         git-push: "true"
         git-commit-message: "terraform-docs: automated updates to Terraform modules README.md"
+

--- a/terraform/cicd.tf
+++ b/terraform/cicd.tf
@@ -42,16 +42,8 @@ resource "aws_iam_policy" "incubator_builder" {
          Resource  = [
             "arn:aws:ecs:us-west-2:${data.aws_caller_identity.current.account_id}:service/incubator-prod/*"
          ]
-      },
-      // allow read secrets
-      {
-        Sid = "SecretsManagerReadAll"
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = "arn:aws:secretsmanager:us-west-2:${data.aws_caller_identity.current.account_id}:secret:*"
       }
+      
     ]
   })
 }

--- a/terraform/cicd.tf
+++ b/terraform/cicd.tf
@@ -42,6 +42,15 @@ resource "aws_iam_policy" "incubator_builder" {
          Resource  = [
             "arn:aws:ecs:us-west-2:${data.aws_caller_identity.current.account_id}:service/incubator-prod/*"
          ]
+      },
+      // allow read home-unite-us secrets
+      {
+        Sid = "SecretsManagerReadHomeUniteUs"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "arn:aws:secretsmanager:us-west-2:${data.aws_caller_identity.current.account_id}:secret:home-unite-us-*"
       }
     ]
   })

--- a/terraform/cicd.tf
+++ b/terraform/cicd.tf
@@ -43,14 +43,14 @@ resource "aws_iam_policy" "incubator_builder" {
             "arn:aws:ecs:us-west-2:${data.aws_caller_identity.current.account_id}:service/incubator-prod/*"
          ]
       },
-      // allow read home-unite-us secrets
+      // allow read secrets
       {
-        Sid = "SecretsManagerReadHomeUniteUs"
+        Sid = "SecretsManagerReadAll"
         Effect = "Allow"
         Action = [
           "secretsmanager:GetSecretValue"
         ]
-        Resource = "arn:aws:secretsmanager:us-west-2:${data.aws_caller_identity.current.account_id}:secret:home-unite-us-*"
+        Resource = "arn:aws:secretsmanager:us-west-2:${data.aws_caller_identity.current.account_id}:secret:*"
       }
     ]
   })


### PR DESCRIPTION
Part 2 of [Pull request 147](https://github.com/hackforla/devops-security/pull/147)

### What changes did you make?
  - Added `incubator-tf-plan` and `incubator-tf-apply` the `role-to-assume` in the `...plan.tf` and `apply.tf` files
  -
  -

### Why did you make the changes (we will use this info to test)?
  - It was requested in [the Issue](https://github.com/hackforla/devops-security/issues/146). 
  -
  -
