### PR TITLE
Add blank issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
@@ -1,0 +1,34 @@
+name: 'Blank Issue Form with Dependency'
+description: 'Standard HackforLA issue form with dependency'
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'dependency', 'draft']
+projects: ['hackforla/73'] # CoP: DevOps: Project Board
+body:
+  - type: textarea
+    id: dependency
+    attributes:
+      label: Dependency
+      description: 'Add dependencies (ideally by issue #)'
+      value: '- [ ]'
+    validations:
+      required: true
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: Clearly state the purpose of this issue in 2 sentences or less
+    validations:
+      required: true
+  - type: textarea
+    id: action-items
+    attributes:
+      label: Action Items
+      description: "List the research to be done, or the steps to be completed. Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task."
+    validations:
+      required: true
+  - type: textarea
+    id: resources-instructions
+    attributes:
+      label: "Resources/Instructions"
+      description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
@@ -1,0 +1,26 @@
+name: 'Blank Issue Form with No Dependency'
+description: 'Standard HackforLA issue form with no dependency'
+labels: ['size: missing', 'role: missing', 'feature: missing', 'complexity: missing', 'milestone: missing', 'draft']
+projects: ['hackforla/73'] # CoP: DevOps: Project Board
+body:
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: Clearly state the purpose of this issue in 2 sentences or less
+    validations:
+      required: true
+  - type: textarea
+    id: action-items
+    attributes:
+      label: Action Items
+      description: "List the research to be done, or the steps to be completed. Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task."
+    validations:
+      required: true
+  - type: textarea
+    id: resources-instructions
+    attributes:
+      label: "Resources/Instructions"
+      description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
+    validations:
+      required: true


### PR DESCRIPTION
### What changes did you make?
  - Added `blank-issue-form-with-no-dependency.yml` and `blank-issue-form-with-dependency.yml`, ported from devops-security.
  - The files are byte-identical to their devops-security counterparts.

### Why did you make the changes (we will use this info to test)?
  - All 18 existing templates here are markdown. Markdown templates cannot mark fields required, and cannot set `projects:` at all — so no template could add an issue to the CoP: DevOps: Project Board. Issues were being added by hand, and the most recent one (#143) never made it onto the board.
  - The forms mark Overview / Action Items / Resources required, and add new issues to `hackforla/73` automatically.
  - All seven labels the forms apply (`size/role/feature/complexity/milestone: missing`, `dependency`, `draft`) already exist in this repo with matching casing — verified against `gh label list`, 0 mismatches.
  - To test: click New Issue, pick either new form, and confirm the required-field validation plus the labels and project shown at the bottom before submitting.

Not included here, tracked separately:
  - The existing `blank-issue.md` is now redundant with the no-dependency form and should be removed, along with the website-inherited templates (Lighthouse, Wave, project-card, etc.) and the empty `custom.md` stub.
  - `feature_request.md` is labeled `documentation`; `enhancement` is likely correct.
  - No template applies `milestone: missing` today except the two added here.