### PR TITLE
Enable 4-day automated backups on incubator-prod-database

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "default" {
   apply_immediately                     = true
   auto_minor_version_upgrade            = true
   availability_zone                     = "us-west-2a"
-  backup_retention_period               = 0
+  backup_retention_period               = 4
   backup_target                         = "region"
   backup_window                         = "03:00-06:00"
   ca_cert_identifier                    = "rds-ca-rsa2048-g1"


### PR DESCRIPTION
Sets `backup_retention_period` to 4 on `incubator-prod-database`, which currently runs with no automated backups and no snapshots.

Closes #149

## Draft on purpose — do not merge until an outage window is scheduled

**Merging this PR is the deploy.** `terraform-apply.yaml` runs `terraform apply` with `auto_approve: true` on every push to `main` touching a `.tf` file, and the instance has `apply_immediately = true`.

**Changing backup retention from 0 to a non-zero value restarts the RDS instance.** This is not a zero-downtime change, and all six projects share this one instance (vrms, civic-tech-index, civic-tech-jobs, home-unite-us, people-depot, access-the-data). Mark ready for review only once the window is booked and announced.

## Before merging, check the plan

The `terraform-plan` output must show an **in-place update** to `aws_db_instance.default` and nothing else. **A plan proposing to replace this resource must not be merged** — `skip_final_snapshot = true` and `deletion_protection = false` mean nothing would stop a destroy.

## Cost

No cost increase. The database holds ~5.8 GiB against a free backup-storage allowance equal to its 100 GiB of allocated storage, so projected backup storage (~13 GiB including the planned manual snapshot) stays well inside the free tier.

## After merging

Post-merge steps are on #149: verify retention reads `4`, take the `incubator-prod-database-pre-pg15` manual snapshot, confirm it reaches `available`, and check the ECS services in `incubator-prod` reconnected.
