### PR TITLE
Upgrade RDS PostgreSQL from 13 to 15

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,6 +27,7 @@
 | Name | Type |
 |------|------|
 | [aws_db_instance.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_parameter_group.postgres15](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_iam_policy.incubator_builder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -1,11 +1,25 @@
-import {
-  to = aws_db_instance.default
-  id = "incubator-prod-database"
-}
+# RDS rejects a major version upgrade that keeps a parameter group from the old
+# engine family, and AWS creates default groups lazily -- default.postgres15
+# does not exist in this account. A managed group also gives future tuning
+# somewhere to live.
+#
+# password_encryption is deliberately left unset: postgres15 sets no value, so
+# the engine default (scram-sha-256) applies to roles created after the upgrade.
+# See hackforla/incubator#150 for the decision.
+resource "aws_db_parameter_group" "postgres15" {
+  name        = "incubator-prod-postgres15"
+  family      = "postgres15"
+  description = "incubator-prod-database, PostgreSQL 15"
 
+  tags = {
+    Name              = "incubator-prod-postgres15"
+    terraform_managed = "true"
+  }
+}
 
 resource "aws_db_instance" "default" {
   allocated_storage                     = 100
+  allow_major_version_upgrade           = true
   apply_immediately                     = true
   auto_minor_version_upgrade            = true
   availability_zone                     = "us-west-2a"
@@ -20,14 +34,14 @@ resource "aws_db_instance" "default" {
   enabled_cloudwatch_logs_exports       = ["postgresql", "upgrade"]
   engine                                = "postgres"
   engine_lifecycle_support              = "open-source-rds-extended-support"
-  engine_version                        = "13.20"
+  engine_version                        = "15"
   iam_database_authentication_enabled   = false
   identifier                            = "incubator-prod-database"
   instance_class                        = "db.t3.small"
   multi_az                              = false
   network_type                          = "IPV4"
-  option_group_name                     = "default:postgres-13"
-  parameter_group_name                  = "default.postgres13"
+  option_group_name                     = "default:postgres-15"
+  parameter_group_name                  = aws_db_parameter_group.postgres15.name
   port                                  = 5432
   publicly_accessible                   = true
   skip_final_snapshot                   = true


### PR DESCRIPTION
Closes #150.

Upgrades the shared `incubator-prod-database` instance from PostgreSQL 13.20 to 15. 13.20 is deprecated and the instance is on paid RDS Extended Support.

## Changes, all in `terraform/database.tf`

- Add `aws_db_parameter_group.postgres15` (`family = "postgres15"`) and point `parameter_group_name` at it. RDS rejects a major upgrade that keeps an old-family group, and `default.postgres15` does not exist in the account — AWS creates default groups lazily, and `default.postgres13` is currently the only one.
- `allow_major_version_upgrade = true`. Absent today; the apply fails outright on a major bump without it.
- `engine_version` `"13.20"` → `"15"`. Major only: `auto_minor_version_upgrade = true` is already set, so pinning a full minor would guarantee drift the next time AWS patches.
- `option_group_name` `"default:postgres-13"` → `"default:postgres-15"`. Same family constraint.
- Remove the `import` block. It was the one-time adoption of the pre-existing instance and has already run.

Left deliberately unchanged, per decisions recorded on #150: `engine_lifecycle_support` stays `open-source-rds-extended-support`, `apply_immediately` stays `true`, and `password_encryption` is unset so the engine default (`scram-sha-256`) applies to roles created after the upgrade.

The file's existing wide `=` alignment is preserved. `terraform fmt` wants to reformat this file, but it did so before this branch as well — all six `.tf` files in the directory are unformatted at `main`. Reformatting is left out of scope so the change stays reviewable.

## Before merging

**Confirm the `terraform-plan` output is an in-place update to `aws_db_instance.default`.** A plan proposing to *replace* this resource must not be merged — `skip_final_snapshot = true` and `deletion_protection = false` mean nothing would stop a destroy of the shared database.

**Merging is the deploy.** `.github/workflows/terraform-apply.yaml` runs `terraform apply` with `auto_approve: true` on every push to `main` touching a `.tf` file, and `apply_immediately = true` means the upgrade begins on merge rather than deferring to the maintenance window. Expect roughly 10-20 minutes of downtime on this data volume.

## Prerequisites already completed

- **Automated backups and baseline snapshot** (#149). `backup_retention_period = 4` is in effect and `incubator-prod-database-pre-pg15` exists.
- **PostGIS extension registration.** `ballotnav_db_dev` and `ballotnav_db_prod` registered PostGIS 3.0.2 while the instance loads 3.4.3 — an RDS minor patch had replaced the binaries without `ALTER EXTENSION ... UPDATE` ever being run. PG15 on RDS has no 3.0.2, so `pg_upgrade` would have failed after taking the instance down. Both databases are now at 3.4.3 with the registered version matching the loaded library. Details in the pre-flight comment on #150.

Pre-flight also confirmed no logical replication slots and no `reg*` columns in any database, both of which would have blocked `pg_upgrade`.

## After merging

Post-merge verification is tracked on #150 and cannot be done from this branch. The most commonly missed step is `ANALYZE` on every database — `pg_upgrade` does not carry optimizer statistics across, so query plans will be poor until it runs.
