### PR TITLE
Remove option_group_name so the RDS upgrade can apply

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -17,6 +17,11 @@ resource "aws_db_parameter_group" "postgres15" {
   }
 }
 
+# option_group_name is deliberately absent. Option groups do nothing for
+# PostgreSQL, and AWS creates the default ones lazily -- naming
+# "default:postgres-15" before it exists fails the apply with
+# OptionGroupNotFoundFault. Leaving the attribute out lets RDS assign the
+# family default itself during the major upgrade. Do not add it back.
 resource "aws_db_instance" "default" {
   allocated_storage                     = 100
   allow_major_version_upgrade           = true
@@ -40,7 +45,6 @@ resource "aws_db_instance" "default" {
   instance_class                        = "db.t3.small"
   multi_az                              = false
   network_type                          = "IPV4"
-  option_group_name                     = "default:postgres-15"
   parameter_group_name                  = aws_db_parameter_group.postgres15.name
   port                                  = 5432
   publicly_accessible                   = true


### PR DESCRIPTION
Fixes the failed apply from #152. Re-opens the work on #150.

## What happened

#152 merged and `terraform apply` failed:

```
Error: updating RDS DB Instance (incubator-prod-database): operation error RDS:
ModifyDBInstance, StatusCode: 404, OptionGroupNotFoundFault:
Specified OptionGroupName: default:postgres-15 not found.
```

AWS creates default option groups lazily, exactly as it does default parameter groups. `default:postgres-15` does not exist in this account, so naming it fails before RDS does any work.

**No damage.** The call was rejected before anything was modified. The instance is still 13.20, `available`, on its original parameter and option groups, with an unchanged endpoint. There was no downtime. `aws_db_parameter_group.postgres15` was created successfully by that run and is already in state.

## The change

Remove `option_group_name` from `aws_db_instance.default` rather than pointing it somewhere else.

Option groups do nothing for PostgreSQL — no options exist for the `postgres` engine — and the attribute is `Optional+Computed` in the AWS provider. With it absent, Terraform stops proposing changes to it and RDS assigns the postgres-15 family default itself during the major upgrade, creating `default:postgres-15` lazily at that point. That is the one moment it can be created, which is why it cannot be named up front.

The alternative, an `aws_db_option_group` resource with `major_engine_version = "15"`, also works but adds a managed resource whose only job is to hold zero options indefinitely.

A comment is included above the resource so the attribute does not get reintroduced.

## Note for whoever refines #150

The action item "Change `option_group_name` from `"default:postgres-13"` to `"default:postgres-15"` — same family constraint" is incorrect, and is what caused the failed apply. The item should say to remove the attribute. The reasoning it gives for parameter groups (AWS creates defaults lazily) applies identically to option groups, but the ticket draws the opposite conclusion for them.

## Before merging

Confirm the plan is an **in-place update** to `aws_db_instance.default` with **0 to destroy**. `skip_final_snapshot = true` and `deletion_protection = false` mean a replace would destroy the shared database.

Merging is the deploy: `apply_immediately = true`, so the upgrade begins on merge. Expect roughly 10-20 minutes of downtime.

Prerequisites remain satisfied — snapshot `incubator-prod-database-pre-pg15`, PostGIS updated to 3.4.3 on both ballotnav databases, no replication slots, no `reg*` columns.
